### PR TITLE
test(auth): expand internal/auth coverage to 70.5%

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -446,5 +449,360 @@ func TestHandleVerifyRecaptcha_RequiresValidTokenWhenConfigured(t *testing.T) {
 	}
 	if !strings.Contains(sentBody, "secret=secret") || !strings.Contains(sentBody, "response=signup-token") {
 		t.Fatalf("unexpected recaptcha verification request body: %s", sentBody)
+	}
+}
+
+// ── RequireVerifiedSessionUser ────────────────────────────────────────────────
+
+func TestRequireVerifiedSessionUser_NoSession(t *testing.T) {
+	svc, _ := newTestService(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	_, ok := svc.RequireVerifiedSessionUser(rr, req)
+
+	if ok {
+		t.Fatal("expected RequireVerifiedSessionUser to fail with no session")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(rr.Body.String(), "authentication_required") {
+		t.Fatalf("expected authentication_required in body, got: %s", rr.Body.String())
+	}
+}
+
+func TestRequireVerifiedSessionUser_UnverifiedEmail(t *testing.T) {
+	svc, st := newTestService(t)
+	u, err := st.UpsertUser("unverified@example.com")
+	if err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	sid, err := st.CreateSession(u.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "od_session", Value: sid})
+	rr := httptest.NewRecorder()
+
+	_, ok := svc.RequireVerifiedSessionUser(rr, req)
+
+	if ok {
+		t.Fatal("expected RequireVerifiedSessionUser to fail for unverified user")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(rr.Body.String(), "email_verification_required") {
+		t.Fatalf("expected email_verification_required in body, got: %s", rr.Body.String())
+	}
+}
+
+func TestRequireVerifiedSessionUser_VerifiedUser(t *testing.T) {
+	svc, st := newTestService(t)
+	u, err := st.AuthenticateOAuth("google", "verified-sub", "verified@example.com", true)
+	if err != nil {
+		t.Fatalf("AuthenticateOAuth: %v", err)
+	}
+	sid, err := st.CreateSession(u.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "od_session", Value: sid})
+	rr := httptest.NewRecorder()
+
+	got, ok := svc.RequireVerifiedSessionUser(rr, req)
+
+	if !ok {
+		t.Fatal("expected RequireVerifiedSessionUser to succeed for verified user")
+	}
+	if got.ID != u.ID {
+		t.Fatalf("user ID mismatch: got %q want %q", got.ID, u.ID)
+	}
+}
+
+// ── HandleWhoAmI ─────────────────────────────────────────────────────────────
+
+func TestHandleWhoAmI_Unauthenticated(t *testing.T) {
+	svc, _ := newTestService(t)
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rr := httptest.NewRecorder()
+
+	svc.HandleWhoAmI(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleWhoAmI_Authenticated(t *testing.T) {
+	svc, st := newTestService(t)
+	u, err := st.UpsertUser("whoami@example.com")
+	if err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	sid, err := st.CreateSession(u.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: "od_session", Value: sid})
+	rr := httptest.NewRecorder()
+
+	svc.HandleWhoAmI(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusOK)
+	}
+	var decoded store.UserRow
+	if err := json.NewDecoder(rr.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if decoded.ID != u.ID {
+		t.Fatalf("user ID mismatch: got %q want %q", decoded.ID, u.ID)
+	}
+}
+
+// ── readOAuthState ────────────────────────────────────────────────────────────
+
+func TestReadOAuthState_Valid(t *testing.T) {
+	svc, _ := newTestService(t)
+	state := "test-state-abc123"
+	req := httptest.NewRequest(http.MethodGet, "/?state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: "od_oauth_state", Value: state})
+
+	if !svc.readOAuthState(req) {
+		t.Fatal("expected readOAuthState to return true for matching state")
+	}
+}
+
+func TestReadOAuthState_NoCookie(t *testing.T) {
+	svc, _ := newTestService(t)
+	req := httptest.NewRequest(http.MethodGet, "/?state=abc", nil)
+
+	if svc.readOAuthState(req) {
+		t.Fatal("expected readOAuthState to return false with no cookie")
+	}
+}
+
+func TestReadOAuthState_Mismatch(t *testing.T) {
+	svc, _ := newTestService(t)
+	req := httptest.NewRequest(http.MethodGet, "/?state=state-abc", nil)
+	req.AddCookie(&http.Cookie{Name: "od_oauth_state", Value: "state-xyz"})
+
+	if svc.readOAuthState(req) {
+		t.Fatal("expected readOAuthState to return false for mismatched state")
+	}
+}
+
+// ── exchangeCode ─────────────────────────────────────────────────────────────
+
+func TestExchangeCode_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"tok-123"}`)
+	}))
+	defer ts.Close()
+
+	body, err := exchangeCode(&http.Client{}, ts.URL, url.Values{"code": {"abc"}})
+	if err != nil {
+		t.Fatalf("exchangeCode: %v", err)
+	}
+	if !strings.Contains(string(body), "tok-123") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestExchangeCode_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad credentials", http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	_, err := exchangeCode(&http.Client{}, ts.URL, url.Values{"code": {"bad"}})
+	if err == nil {
+		t.Fatal("expected error for 4xx response")
+	}
+}
+
+// ── HandleGoogleCallback ──────────────────────────────────────────────────────
+
+func TestHandleGoogleCallback_InvalidState(t *testing.T) {
+	svc, _ := newTestService(t)
+	t.Setenv("GOOGLE_CLIENT_ID", "google-client")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state=bad&code=abc", nil)
+	rr := httptest.NewRecorder()
+
+	svc.HandleGoogleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleGoogleCallback_HappyPath(t *testing.T) {
+	svc, _ := newTestService(t)
+	t.Setenv("GOOGLE_CLIENT_ID", "google-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "google-secret")
+
+	// Single test server handles both token exchange and userinfo.
+	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/token":
+			_, _ = fmt.Fprint(w, `{"access_token":"test-access-tok"}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"sub":"google-sub-1","email":"google@example.com","email_verified":true}`)
+		}
+	}))
+	defer oauthServer.Close()
+
+	// Redirect all outbound calls to the mock server.
+	svc.SetHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			req.URL.Host = strings.TrimPrefix(oauthServer.URL, "http://")
+			req.URL.Scheme = "http"
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	})
+
+	state := "test-google-state"
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state="+state+"&code=test-code", nil)
+	req.AddCookie(&http.Cookie{Name: "od_oauth_state", Value: state})
+	rr := httptest.NewRecorder()
+
+	svc.HandleGoogleCallback(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d want %d; body=%s", rr.Code, http.StatusSeeOther, rr.Body.String())
+	}
+	found := false
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "od_session" && c.Value != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected od_session cookie after google oauth callback")
+	}
+}
+
+// ── RegisterRoutes ────────────────────────────────────────────────────────────
+
+func TestRegisterRoutes_RegistersAllExpectedRoutes(t *testing.T) {
+	svc, _ := newTestService(t)
+	mux := http.NewServeMux()
+	svc.RegisterRoutes(mux)
+
+	for _, path := range []string{
+		"GET /auth/signup",
+		"GET /auth/login",
+		"GET /auth/me",
+		"GET /auth/google/login",
+		"GET /auth/google/callback",
+		"GET /auth/facebook/login",
+		"GET /auth/facebook/callback",
+	} {
+		parts := strings.SplitN(path, " ", 2)
+		req := httptest.NewRequest(parts[0], parts[1], nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		if rr.Code == http.StatusNotFound {
+			t.Errorf("route %s returned 404 — not registered", path)
+		}
+	}
+}
+
+// ── SendVerificationEmail via mock emailer ────────────────────────────────────
+
+type mockEmailer struct {
+	lastEmail string
+	lastURL   string
+	lastCode  string
+}
+
+func (m *mockEmailer) SendVerificationEmail(_ context.Context, toEmail, verifyURL, code string) error {
+	m.lastEmail = toEmail
+	m.lastURL = verifyURL
+	m.lastCode = code
+	return nil
+}
+
+func TestHandleRequestVerification_CallsEmailerWhenConfigured(t *testing.T) {
+	svc, _ := newTestService(t)
+	mock := &mockEmailer{}
+	svc.emailer = mock
+
+	form := url.Values{}
+	form.Set("email", "emailer@example.com")
+	req := httptest.NewRequest(http.MethodPost, "/auth/request-verification", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	svc.HandleRequestVerification(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusOK)
+	}
+	if mock.lastEmail != "emailer@example.com" {
+		t.Fatalf("emailer.lastEmail=%q want %q", mock.lastEmail, "emailer@example.com")
+	}
+	if !strings.Contains(mock.lastURL, "/auth/verify") {
+		t.Fatalf("emailer.lastURL=%q should contain /auth/verify", mock.lastURL)
+	}
+	if mock.lastCode == "" {
+		t.Fatal("emailer.lastCode should not be empty")
+	}
+}
+
+func TestHandleRequestVerification_UsesSesEmailFromSession(t *testing.T) {
+	svc, st := newTestService(t)
+	u, err := st.UpsertUser("session-verify@example.com")
+	if err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	sid, err := st.CreateSession(u.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// POST with no email — should fall back to session user's email.
+	req := httptest.NewRequest(http.MethodPost, "/auth/request-verification", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "od_session", Value: sid})
+	rr := httptest.NewRecorder()
+
+	svc.HandleRequestVerification(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusOK)
+	}
+}
+
+// ── HandleVerifyEmail via JSON ────────────────────────────────────────────────
+
+func TestHandleVerifyEmail_ByTokenJSON(t *testing.T) {
+	svc, st := newTestService(t)
+	email := "json-token@example.com"
+	token, _, err := st.CreateEmailVerification(email, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"token": token})
+	req := httptest.NewRequest(http.MethodPost, "/auth/verify", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	svc.HandleVerifyEmail(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d want %d; body=%s", rr.Code, http.StatusSeeOther, rr.Body.String())
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -389,7 +389,10 @@ func TestHandleRequestVerification_RequiresValidReCAPTCHAWhenConfigured(t *testi
 	var sentBody string
 	svc.SetHTTPClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			b, _ := io.ReadAll(req.Body)
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("ReadAll: %v", err)
+			}
 			sentBody = string(b)
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -427,7 +430,10 @@ func TestHandleVerifyRecaptcha_RequiresValidTokenWhenConfigured(t *testing.T) {
 	var sentBody string
 	svc.SetHTTPClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			b, _ := io.ReadAll(req.Body)
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("ReadAll: %v", err)
+			}
 			sentBody = string(b)
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -690,6 +696,69 @@ func TestHandleGoogleCallback_HappyPath(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected od_session cookie after google oauth callback")
+	}
+}
+
+// ── HandleFacebookCallback ────────────────────────────────────────────────────
+
+func TestHandleFacebookCallback_InvalidState(t *testing.T) {
+	svc, _ := newTestService(t)
+	t.Setenv("FACEBOOK_CLIENT_ID", "fb-client")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/facebook/callback?state=bad&code=abc", nil)
+	rr := httptest.NewRecorder()
+
+	svc.HandleFacebookCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleFacebookCallback_HappyPath(t *testing.T) {
+	svc, _ := newTestService(t)
+	t.Setenv("FACEBOOK_CLIENT_ID", "fb-client")
+	t.Setenv("FACEBOOK_CLIENT_SECRET", "fb-secret")
+
+	// Single test server handles both token exchange and userinfo.
+	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v19.0/oauth/access_token":
+			_, _ = fmt.Fprint(w, `{"access_token":"fb-test-tok"}`)
+		default:
+			_, _ = fmt.Fprint(w, `{"id":"fb-user-1","email":"fb@example.com"}`)
+		}
+	}))
+	defer oauthServer.Close()
+
+	// Redirect all outbound calls to the mock server.
+	svc.SetHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			req.URL.Host = strings.TrimPrefix(oauthServer.URL, "http://")
+			req.URL.Scheme = "http"
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	})
+
+	state := "test-fb-state"
+	req := httptest.NewRequest(http.MethodGet, "/auth/facebook/callback?state="+state+"&code=test-code", nil)
+	req.AddCookie(&http.Cookie{Name: "od_oauth_state", Value: state})
+	rr := httptest.NewRecorder()
+
+	svc.HandleFacebookCallback(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d want %d; body=%s", rr.Code, http.StatusSeeOther, rr.Body.String())
+	}
+	found := false
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "od_session" && c.Value != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected od_session cookie after facebook oauth callback")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds mock emailer struct implementing `verificationEmailSender` interface for dependency injection in tests
- Adds Google OAuth mock using `httptest.NewServer` + `roundTripFunc` to intercept outbound HTTP calls
- Covers session verification middleware, `WhoAmI` handler, OAuth state cookie validation, email verification handlers, and route registration

## Coverage
`internal/auth`: 44.4% → 70.5%

## Acceptance criteria
- [x] `internal/auth` coverage ≥ 70%
- [x] All new tests pass
- [x] No mocks that duplicate production logic

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)